### PR TITLE
fix(middleware): Secure rate limiter for reverse proxy environments

### DIFF
--- a/cmd/app/server/main.go
+++ b/cmd/app/server/main.go
@@ -71,7 +71,11 @@ func NewApp() (*App, error) {
 		sugar.Fatalf("Failed to load TLS credentials: %v", err)
 		return nil, err
 	}
-	rateLimiter := middlewares.NewRateLimiter(5, 10)
+
+	// Initialize rate limiter with default trusted proxies
+	trustedProxies := middlewares.DefaultTrustedProxies()
+	sugar.Infof("Initializing rate limiter with trusted proxies: %v", trustedProxies)
+	rateLimiter := middlewares.NewRateLimiter(5, 10, trustedProxies)
 
 	// Create the gRPC server with TLS and middleware.
 	grpcServer := grpc.NewServer(

--- a/pkg/middlewares/middlewares_test.go
+++ b/pkg/middlewares/middlewares_test.go
@@ -48,7 +48,7 @@ func TestCORSMiddleware(t *testing.T) {
 
 // Test Rate Limiting Middleware
 func TestRateLimiter(t *testing.T) {
-	limiter := NewRateLimiter(1, 1) // 1 request per second
+	limiter := NewRateLimiter(1, 1, DefaultTrustedProxies()) // 1 request per second
 
 	clientID := "test-client"
 

--- a/pkg/middlewares/rate_limiter.go
+++ b/pkg/middlewares/rate_limiter.go
@@ -2,40 +2,70 @@ package middlewares
 
 import (
 	"context"
+	"net"
+	"strings"
 	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 )
 
 // RateLimiter structure
 type RateLimiter struct {
-	mu       sync.Mutex
-	limiters map[string]*rate.Limiter
-	rate     rate.Limit
-	burst    int
+	mu             sync.Mutex
+	limiters       map[string]*rate.Limiter
+	rate           rate.Limit
+	burst          int
+	trustedProxies map[string]bool
+	maxLimiters    int
 }
 
-// NewRateLimiter initializes a rate limiter
-func NewRateLimiter(r rate.Limit, b int) *RateLimiter {
+// NewRateLimiter initializes a rate limiter with configurable rate, burst, and trusted proxies
+func NewRateLimiter(r rate.Limit, b int, proxies []string) *RateLimiter {
+	trusted := make(map[string]bool)
+	for _, proxy := range proxies {
+		if isValidIP(proxy) {
+			trusted[proxy] = true
+		}
+	}
+
 	return &RateLimiter{
-		limiters: make(map[string]*rate.Limiter),
-		rate:     r,
-		burst:    b,
+		limiters:       make(map[string]*rate.Limiter),
+		rate:           r,
+		burst:          b,
+		trustedProxies: trusted,
+		maxLimiters:    10000, // Default maximum number of limiters to prevent memory leaks
 	}
 }
 
-// getLimiter gets or creates a rate limiter for a specific client
+// isValidIP checks if a string is a valid IP address
+func isValidIP(ip string) bool {
+	return net.ParseIP(ip) != nil
+}
+
+// GetLimiter gets or creates a rate limiter for a specific client
 func (r *RateLimiter) GetLimiter(clientID string) *rate.Limiter {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Return existing limiter if it exists
 	if limiter, exists := r.limiters[clientID]; exists {
 		return limiter
+	}
+
+	// Prevent memory leaks by enforcing a maximum number of limiters
+	if len(r.limiters) >= r.maxLimiters {
+		// Simple eviction strategy: remove one random entry
+		// For production, consider using LRU or similar algorithm
+		for k := range r.limiters {
+			delete(r.limiters, k)
+			break
+		}
 	}
 
 	limiter := rate.NewLimiter(r.rate, r.burst)
@@ -52,6 +82,11 @@ func (r *RateLimiter) GetLimiter(clientID string) *rate.Limiter {
 	return limiter
 }
 
+// DefaultTrustedProxies returns a list of commonly trusted proxy IPs
+func DefaultTrustedProxies() []string {
+	return []string{"127.0.0.1", "::1"}
+}
+
 // RateLimiterInterceptor applies rate limiting
 func (r *RateLimiter) RateLimiterInterceptor(
 	ctx context.Context,
@@ -59,16 +94,44 @@ func (r *RateLimiter) RateLimiterInterceptor(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler) (interface{}, error) {
 
-	// Extract client identifier (can use IP or API key)
-	// Extract the client's IP address from the context using the peer package.
 	p, ok := peer.FromContext(ctx)
-	var clientID string
-	if ok {
-		clientID = p.Addr.String()
-		// Optionally, further parse clientID if needed (e.g., remove port information)
-	} else {
-		clientID = "unknown"
+	if !ok {
+		return nil, status.Errorf(codes.Internal, "could not determine peer")
 	}
+
+	peerIP, _, err := net.SplitHostPort(p.Addr.String())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "invalid peer address: %v", err)
+	}
+
+	var clientID string
+
+	// Only trust proxy headers if the request is from a trusted proxy
+	if r.trustedProxies[peerIP] {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			// Check X-Forwarded-For (may be a comma-separated list)
+			if xff := md.Get("x-forwarded-for"); len(xff) > 0 && xff[0] != "" {
+				ips := strings.Split(xff[0], ",")
+				if len(ips) > 0 && strings.TrimSpace(ips[0]) != "" {
+					cleanIP := strings.TrimSpace(ips[0])
+					if isValidIP(cleanIP) {
+						clientID = cleanIP
+					}
+				}
+			} else if xri := md.Get("x-real-ip"); len(xri) > 0 && xri[0] != "" {
+				cleanIP := strings.TrimSpace(xri[0])
+				if isValidIP(cleanIP) {
+					clientID = cleanIP
+				}
+			}
+		}
+	}
+
+	// If no trusted clientID was found from headers, use the peer's IP
+	if clientID == "" {
+		clientID = peerIP
+	}
+
 	limiter := r.GetLimiter(clientID)
 	if !limiter.Allow() {
 		return nil, status.Errorf(codes.ResourceExhausted, "Too many requests, slow down")


### PR DESCRIPTION
Fixes #105

This pull request addresses a critical Denial of Service (DoS) vulnerability in the gRPC rate-limiting middleware.

The original implementation used the direct peer's IP address for rate-limiting. In a production environment behind a reverse proxy or Kubernetes Ingress, this would cause all user traffic to be bucketed under a single proxy IP. A single malicious user could easily exhaust the request quota, effectively blocking all legitimate users.

This PR re-architects the rate limiter to correctly and securely identify the true client IP address by trusting proxy headers only when the request originates from a configurable list of trusted sources.

#### Changes

This PR hardens the `rate_limiter.go` middleware and its integration by:

-   **Introducing a Trusted Proxy Model:**
    -   The `RateLimiter` is now configurable via `NewRateLimiter` to accept a list of trusted proxy IP addresses.
    -   The `RateLimiterInterceptor` only inspects `X-Forwarded-For` and `X-Real-IP` headers if the direct peer's IP is on this trusted list, preventing IP spoofing from external clients.
    -   If the peer is not trusted or headers are absent, it safely falls back to using the peer's IP.

-   **Adding Input Validation and Hardening:**
    -   An `isValidIP` check has been added to validate IPs parsed from headers before they are used.
    -   A `maxLimiters` cap is now enforced in the `GetLimiter` function to prevent potential memory exhaustion from unbounded map growth.

-   **Improving Integration and Configuration:**
    -   The server initialization in `cmd/app/server/main.go` now uses the new configurable `NewRateLimiter` constructor.
    -   A `DefaultTrustedProxies` helper has been added to provide a sensible default for local development (`127.0.0.1`, `::1`).

-   **Updating Tests:**
    -   The unit tests in `middlewares_test.go` have been updated to align with the new constructor.